### PR TITLE
Added terraform configurations for creating GCP Serverless VPC Connector

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 0.13.1" # see https://releases.hashicorp.com/terraform/
+}
+
+locals {
+  vpc_connector_name = format("%s-%s", "vpc-connector", var.name_suffix)
+}
+
+resource "google_project_service" "serverless_vpc_api" {
+  service            = "vpcaccess.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_vpc_access_connector" "vpc_connector" {
+  name          = local.vpc_connector_name
+  region        = var.vpc_connector_region
+  ip_cidr_range = var.ip_cidr_range
+  network       = var.vpc_network_name
+  depends_on    = [google_project_service.serverless_vpc_api]
+  timeouts {
+    create = var.vpc_connector_timeout
+    update = var.vpc_connector_timeout
+    delete = var.vpc_connector_timeout
+  }
+}
+
+data "google_client_config" "google_client" {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "vpc_connector_name" {
+  description = "Serverless VPC Connector Name"
+  value       = local.vpc_connector_name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,29 @@
+variable "name_suffix" {
+  description = "An arbitrary suffix that will be added to the end of the resource name(s). For example: an environment name, a business-case name, a numeric id, etc."
+  type        = string
+  validation {
+    condition     = length(var.name_suffix) <= 14
+    error_message = "A max of 14 character(s) are allowed."
+  }
+}
+
+variable "vpc_network_name" {
+  description = "VPC Network Name"
+  type        = string
+}
+
+variable "vpc_connector_region" {
+  description = "VPC Conector Region"
+  type        = string
+}
+
+variable "ip_cidr_range" {
+  description = "VPC Connector CIDR IP"
+  type        = string
+}
+
+variable "vpc_connector_timeout" {
+  description = "How long a VPC Connector operation is allowed to take before being considered a failure."
+  type        = string
+  default     = "10m"
+}


### PR DESCRIPTION
Added initial configuration for GCP Serverless VPC Connector.

**About Serverless VPC Access**
Serverless VPC Access enables you to connect from a serverless environment on Google Cloud (Cloud Run (fully managed), Cloud Functions, or the App Engine standard environment) directly to your VPC network. This connection makes it possible for your serverless environment to access Compute Engine VM instances, Memorystore instances, and any other resources with an internal IP address.
[Read more](https://cloud.google.com/vpc/docs/configure-serverless-vpc-access)

**Code added**
This initial configuration (1.0.0) contains main.tf, variables.tf and outputs.tf. The code is previously tested and working absolutely well.
The end-user need to supply all required value in order to create Serverless VPC Access.
There is **no** minimum and maximum throughput of the connector added in initial version.

_**Note:** In order to create Serverless VPC Access, there must be a VPC Network._

```
module "serverless_vpc" {`
  source               = "airasia/serverless_vpc_access/google"
  providers            = { google = google }
  name_suffix          = local.name_suffix
  vpc_connector_region = "asia-east2"
  ip_cidr_range        = "10.8.0.0/28"
  vpc_network_name     = module.vpc.name
}
